### PR TITLE
US-13 Changed labels for repeat and stop repeat for events

### DIFF
--- a/src/net/sf/memoranda/ui/EventDialog.java
+++ b/src/net/sf/memoranda/ui/EventDialog.java
@@ -181,7 +181,7 @@ public class EventDialog extends JDialog implements WindowListener {
         gbc.insets = new Insets(5, 5, 5, 40);
         gbc.anchor = GridBagConstraints.WEST;
         repeatPanel.add(lblDays, gbc);
-        lblSince.setText(Local.getString("Since"));
+        lblSince.setText(Local.getString("Start Repeating"));
         lblSince.setMinimumSize(new Dimension(70, 16));
         gbc = new GridBagConstraints();
         gbc.gridx = 4; gbc.gridy = 1;
@@ -253,7 +253,7 @@ public class EventDialog extends JDialog implements WindowListener {
         gbc.anchor = GridBagConstraints.WEST;
         repeatPanel.add(weekdaysCB, gbc);
         enableEndDateCB.setHorizontalAlignment(SwingConstants.RIGHT);
-        enableEndDateCB.setText(Local.getString("Till"));
+        enableEndDateCB.setText(Local.getString("Stop Repeating After"));
         enableEndDateCB.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 enableEndDateCB_actionPerformed(e);

--- a/src/net/sf/memoranda/ui/EventDialogTest.java
+++ b/src/net/sf/memoranda/ui/EventDialogTest.java
@@ -1,0 +1,42 @@
+package net.sf.memoranda.ui;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import org.junit.Test;
+
+import net.sf.memoranda.util.Local;
+
+public class EventDialogTest {
+	
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+	}
+
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+	}
+	
+
+
+	@Test
+	public void jbInittest() {
+		JLabel lblTest = new JLabel();
+		JCheckBox enableTest= new JCheckBox();
+		 
+		lblTest.setText(Local.getString("Start Repeating"));
+		
+		enableTest.setText(Local.getString("Stop Repeating After"));
+		
+		assertEquals("Start Repeating", lblTest.getText());
+		assertEquals("Stop Repeating After", enableTest.getText());
+	}
+
+}


### PR DESCRIPTION
Turns out the functionality already exists to stop repeating an event. So I really did not change anything except the labels for it to be more clear.